### PR TITLE
fixed issue parsing numpy array of times when writing irregular ts

### DIFF
--- a/pydsstools/heclib/dss/HecDss.py
+++ b/pydsstools/heclib/dss/HecDss.py
@@ -137,8 +137,8 @@ class Open(_Open):
             julianbasedate = 0
             time_values = []
 
-            if not times or not isinstance(times,(list,tuple)):
-                logging.error('times for irregular time-series is not non-empty list or tuple')
+            if times is None or not len(times):
+                logging.error('times for irregular time-series is not non-empty list, tuple, or array')
                 return
 
             if not (tsc.numberValues == len(times)):


### PR DESCRIPTION
When writing an irregular time series, there is a check to make sure that `times` exists as is either an instance of `list` or `tuple`. However, while numpy arrays work fine for regular time series, it fails for irregular time series. In this PR I amended the problematic code to also accept numpy arrays when writing irregular time series. This check fails in its current form when given numpy arrays both because `if not times` is ambiguous for an array and `isinstance(times, (list, tuple))` evaluates to `False`, so I changed `if not times` to `if times is None` (less ambiguous) and I allowed `times` to be an instance of a `numpy.ndarray` for irregular time series as well.